### PR TITLE
iOS 10 dealocation crash fix

### DIFF
--- a/MultilineTextField/Classes/MultilineTextField.swift
+++ b/MultilineTextField/Classes/MultilineTextField.swift
@@ -116,11 +116,14 @@ public class MultilineTextField: UITextView {
    }
    
    deinit {
-      fieldObservations.forEach { $0.invalidate() }
-      
-      fieldObservations.removeAll()
-      
-      NotificationCenter.default.removeObserver(self)
+      removeObservers()
+   }
+
+   public override func willMove(toSuperview newSuperview: UIView?) {
+      super.willMove(toSuperview: newSuperview)
+      if newSuperview == nil {
+         removeObservers()
+      }
    }
    
    func initializeUI() {
@@ -167,6 +170,12 @@ public class MultilineTextField: UITextView {
             self?.placeholderView.textContainer.lineFragmentPadding = textContainer.lineFragmentPadding
          }
       )
+   }
+
+   private func removeObservers() {
+      fieldObservations.forEach { $0.invalidate() }
+      fieldObservations.removeAll()
+      NotificationCenter.default.removeObserver(self)
    }
    
    @objc private func textViewDidChange(notification: Notification) {


### PR DESCRIPTION
Hi as @oenama noticed in #1 pod causes crash if it is presented on screen which pop by `UINavigationController`.
To fix that we can remove observers when `MultilineTextField` will be removed from superview.
resolve #1 